### PR TITLE
Fix session load

### DIFF
--- a/lib/Cro/HTTP/Session/Red.pm6
+++ b/lib/Cro/HTTP/Session/Red.pm6
@@ -12,7 +12,7 @@ method load($session-id) {
         }
     }
     my $loaded = Model.^load: $session-id;
-    $loaded // Model
+    $loaded // self.create($session-id)
 }
 
 method create($id) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -12,7 +12,7 @@ my Cro::HTTP::Session::Red[Bla] $session .= new: cookie-name => "bla";
 
 my $s = $session.load("abc");
 isa-ok $s, Bla;
-ok not $s.defined;
+ok $s.defined;
 
 my $created = Bla.^create: :id<abc>;
 isa-ok $created, Bla;


### PR DESCRIPTION
Method `load` must always return a definite user session object. To get
this straighten out we must call method `create` using the session id
passed over to `load` if no DB record found.