### PR TITLE
Re-fix the problem with missing session

### DIFF
--- a/lib/Cro/HTTP/Session/Red.pm6
+++ b/lib/Cro/HTTP/Session/Red.pm6
@@ -11,8 +11,7 @@ method load($session-id) {
             .rethrow
         }
     }
-    my $loaded = Model.^load: $session-id;
-    $loaded // self.create($session-id)
+    Model.^load($session-id) // fail("No session with ID " ~ $session-id)
 }
 
 method create($id) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -3,6 +3,8 @@ use Test;
 use Red;
 use Cro::HTTP::Session::Red;
 
+plan 10;
+
 model Bla { has Str $.id is id; has Str $.a is rw is column{ :nullable } }
 
 my $*RED-DB = database "SQLite";
@@ -11,8 +13,7 @@ Bla.^create-table: :if-not-exists;
 my Cro::HTTP::Session::Red[Bla] $session .= new: cookie-name => "bla";
 
 my $s = $session.load("abc");
-isa-ok $s, Bla;
-ok $s.defined;
+isa-ok $s, Failure;
 
 my $created = Bla.^create: :id<abc>;
 isa-ok $created, Bla;


### PR DESCRIPTION
After more through investigation of `Cro::HTTP::Session::Persistent` it became clear that `load` method must not do autovivifaction of a session record if it's missing in the DB. Instead it must return a `Failure`. In this case `Cro::HTTP::Session::Persistent` will correctly create a new session.