### PR TITLE
After all, method `load` must throw when session id isn't found

### DIFF
--- a/lib/Cro/HTTP/Session/Red.pm6
+++ b/lib/Cro/HTTP/Session/Red.pm6
@@ -4,14 +4,22 @@ use Cro::HTTP::Session::Persistent;
 unit role Cro::HTTP::Session::Red:ver<0.0.2>:auth<cpan:FCO>[::Model Red::Model];
 also does Cro::HTTP::Session::Persistent[Model];
 
+my class X::Session::NotLoaded is Exception {
+    has $.session-id is required;
+    method message { "No session with ID " ~ $!session-id }
+}
+
 method load($session-id) {
     CATCH {
+        when X::Session::NotLoaded {
+            .rethrow
+        }
         default {
             .note;
             .rethrow
         }
     }
-    Model.^load($session-id) // fail("No session with ID " ~ $session-id)
+    Model.^load($session-id) // X::Session::NotLoaded.new(:$session-id).throw
 }
 
 method create($id) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -12,13 +12,15 @@ Bla.^create-table: :if-not-exists;
 
 my Cro::HTTP::Session::Red[Bla] $session .= new: cookie-name => "bla";
 
-my $s = $session.load("abc");
-isa-ok $s, Failure;
+throws-like { $session.load("abc") },
+    Exception,
+    "attempt to load non-existing session throws",
+    :message(/<< ID \s abc >>/);
 
 my $created = Bla.^create: :id<abc>;
 isa-ok $created, Bla;
 
-$s = $session.load("abc");
+my $s = $session.load("abc");
 isa-ok $s, Bla;
 ok $s.defined;
 is-deeply $s, $created;


### PR DESCRIPTION
Returning a `Failure` is less than reliable because it doesn't always throw. Worse, the `Failure` ends up being recorded in `request.auth` causing all sorts of confusion.

Sorry for the previous incomplete fix. I wonder how did it work with `fail` all this time as it should've been.